### PR TITLE
Test

### DIFF
--- a/random-float.cabal
+++ b/random-float.cabal
@@ -23,3 +23,19 @@ executable random-float
         splitmix >=0.0.4,
         bytestring -any,
         mtl -any
+
+test-suite doctest
+    hs-source-dirs:   test
+    default-language: Haskell2010
+
+    if impl(ghc >=8.0.2)
+        type:          exitcode-stdio-1.0
+        main-is:       Doctest.hs
+        build-depends:
+            base >=4.12 && <4.14,
+            doctest >=0.15 && <0.18,
+            random-float -any
+
+    else
+        type:    exitcode-stdio-1.0
+        main-is: NoDoctest.hs

--- a/random-float.cabal
+++ b/random-float.cabal
@@ -5,13 +5,12 @@ license:            LGPL-3
 build-type:         Simple
 extra-source-files: CHANGELOG.md
 
-executable random-float
-    main-is:          Main.hs
-    hs-source-dirs:   src
-    other-modules:
+library
+    exposed-modules:
         MonadIEEE
         Uniform
 
+    hs-source-dirs:   src
     default-language: Haskell2010
     ghc-options:
         -Weverything -Wno-implicit-prelude -Wno-missing-export-lists
@@ -20,9 +19,11 @@ executable random-float
 
     build-depends:
         base >=4.12 && <4.14,
-        splitmix >=0.0.4,
         bytestring -any,
-        mtl -any
+        mtl -any,
+        splitmix >=0.0.4,
+        statistics -any,
+        vector -any
 
 test-suite doctest
     hs-source-dirs:   test
@@ -39,3 +40,23 @@ test-suite doctest
     else
         type:    exitcode-stdio-1.0
         main-is: NoDoctest.hs
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    hs-source-dirs:   test
+    default-language: Haskell2010
+    ghc-options:
+        -Weverything -Wno-implicit-prelude -Wno-missing-export-lists
+        -Wno-missing-local-signatures -Wno-name-shadowing
+        -Wno-monomorphism-restriction -Wno-safe -O2
+
+    build-depends:
+        base >=4.12 && <4.14,
+        hspec -any,
+        genvalidity-hspec -any,
+        vector -any,
+        statistics -any,
+        splitmix -any,
+        mtl -any,
+        random-float -any

--- a/random-float.cabal
+++ b/random-float.cabal
@@ -49,12 +49,12 @@ test-suite spec
     ghc-options:
         -Weverything -Wno-implicit-prelude -Wno-missing-export-lists
         -Wno-missing-local-signatures -Wno-name-shadowing
-        -Wno-monomorphism-restriction -Wno-safe -O2
+        -Wno-monomorphism-restriction -Wno-safe
 
     build-depends:
         base >=4.12 && <4.14,
         hspec -any,
-        genvalidity-hspec -any,
+        hspec-expectations -any,
         vector -any,
         statistics -any,
         splitmix -any,

--- a/src/MonadIEEE.hs
+++ b/src/MonadIEEE.hs
@@ -11,7 +11,6 @@
 module MonadIEEE where
 
 import Control.Arrow (first)
-import Data.List (group, sort)
 import Control.Exception (assert)
 import Control.Monad.State.Strict (State, state)
 import Data.Bits
@@ -23,7 +22,8 @@ import Data.Bits
     unsafeShiftR,
     xor,
   )
-import Data.Proxy (Proxy(..))
+import Data.List (group, sort)
+import Data.Proxy (Proxy (..))
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Float
   ( castDoubleToWord64,

--- a/src/MonadIEEE.hs
+++ b/src/MonadIEEE.hs
@@ -11,6 +11,7 @@
 module MonadIEEE where
 
 import Control.Arrow (first)
+import Data.List (group, sort)
 import Control.Exception (assert)
 import Control.Monad.State.Strict (State, state)
 import Data.Bits
@@ -22,7 +23,7 @@ import Data.Bits
     unsafeShiftR,
     xor,
   )
-import Data.Proxy (Proxy)
+import Data.Proxy (Proxy(..))
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Float
   ( castDoubleToWord64,
@@ -56,6 +57,7 @@ data Unsigned f e s = U {uExponent :: e, uSignificand :: s}
 
 instance (Ord e, Ord s) => Ord (Unsigned f e s) where
   (U ea sa) <= (U eb sb) = ea < eb || (ea == eb && sa <= sb)
+  {-# INLINE (<=) #-}
 
 toUnsigned :: Signed f e s -> Unsigned f e s
 toUnsigned S {sExponent, sSignificand} = U sExponent sSignificand
@@ -181,6 +183,7 @@ instance Ord Binary8 where
       xNegative = 0 /= m .&. wx
       yNegative = 0 /= m .&. wy
       positive = assemble . toPositive . toUnsigned . explode
+  {-# INLINE (<=) #-}
 
 binary8SignificandWidth, binary8ExponentWidth, binary8ExponentBias :: Int
 binary8SignificandWidth = 3

--- a/src/MonadIEEE.hs
+++ b/src/MonadIEEE.hs
@@ -20,10 +20,8 @@ import Data.Bits
     countLeadingZeros,
     unsafeShiftL,
     unsafeShiftR,
-    xor,
   )
-import Data.List (group, sort)
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Float
   ( castDoubleToWord64,

--- a/src/Uniform.hs
+++ b/src/Uniform.hs
@@ -54,7 +54,14 @@ uniform x y
   | otherwise = assemble <$> uniformSigned (explode x) (explodeUnsigned y)
   where
     explodeUnsigned = toUnsigned . explode
-    uniformSigned x b = drawSigned x b >>= downeyShiftSigned x b
+
+uniformSigned ::
+  MonadIEEE m f e s =>
+  Signed f e s ->
+  Unsigned f e s ->
+  m (Signed f e s)
+uniformSigned x b = drawSigned x b >>= downeyShiftSigned x b
+{-# INLINEABLE uniformSigned #-}
 
 drawSigned ::
   MonadIEEE m f e s =>
@@ -71,6 +78,7 @@ drawSigned x b
   where
     a = toUnsigned x
     y = toPositive b
+{-# INLINEABLE drawSigned #-}
 
 -- | [-b, b]
 proposeSymmetric ::
@@ -82,6 +90,7 @@ proposeSymmetric b =
   bool toPositive toNegative <$> drawBool p <*> proposeUnsigned zero b
   where
     p = Proxy :: Proxy f
+{-# INLINEABLE proposeSymmetric #-}
 
 -- | [a, b)
 proposeUnsigned ::
@@ -93,6 +102,7 @@ proposeUnsigned a@(U ea _) b@(U eb _)
   | ea == eb = drawExponentDiffZero a b
   | succ ea == eb = proposeExponentDiffOne a b
   | otherwise = proposeExponentDiffGreaterOne a b
+{-# INLINEABLE proposeUnsigned #-}
 
 -- | [2^e + sx, 2^e + sy)
 drawExponentDiffZero ::
@@ -104,6 +114,7 @@ drawExponentDiffZero ::
 drawExponentDiffZero (U ea sa) (U eb sb) =
   assert (ea == eb && sa < sb) $
     U ea <$> ((sa +) <$> drawSignificand (Proxy :: Proxy f) (pred sb - sa))
+{-# INLINEABLE drawExponentDiffZero #-}
 
 -- | [2^ex + sx, 2^(ex+1) + sy)
 proposeExponentDiffOne ::
@@ -119,6 +130,7 @@ proposeExponentDiffOne (U ea sa) (U eb sb) =
   where
     p = Proxy :: Proxy f
     sz = max (min sb (pred sb)) (maxSignificand p - sa)
+{-# INLINEABLE proposeExponentDiffOne #-}
 
 -- | [2^ex + sx, 2^ey + sy)
 proposeExponentDiffGreaterOne ::
@@ -133,6 +145,7 @@ proposeExponentDiffGreaterOne (U ea _) (U eb _) =
       <*> drawSignificand p (maxSignificand p)
   where
     p = Proxy :: Proxy f
+{-# INLINEABLE proposeExponentDiffGreaterOne #-}
 
 -- | @[x, b)@ to @[x, b]@
 downeyShiftSigned ::
@@ -149,6 +162,7 @@ downeyShiftSigned x b u
   where
     a = toUnsigned x
     v = toUnsigned u
+{-# INLINEABLE downeyShiftSigned #-}
 
 -- | [a, b) to [a, b]
 downeyShiftUnsigned ::
@@ -164,3 +178,4 @@ downeyShiftUnsigned a b u@(U eu su)
   | otherwise = return u
   where
     p = Proxy :: Proxy f
+{-# INLINEABLE downeyShiftUnsigned #-}

--- a/src/Uniform.hs
+++ b/src/Uniform.hs
@@ -10,8 +10,8 @@ import Data.Bool (bool)
 import Data.Proxy (Proxy (Proxy))
 import MonadIEEE
   ( MonadIEEE,
-    Signed (..),
-    Unsigned (..),
+    Signed (sNegative),
+    Unsigned (U),
     assemble,
     drawBool,
     drawExponent,

--- a/src/Uniform.hs
+++ b/src/Uniform.hs
@@ -129,7 +129,7 @@ proposeExponentDiffOne (U ea sa) (U eb sb) =
     return $ U e (if e == eb then s else maxSignificand p - s)
   where
     p = Proxy :: Proxy f
-    sz = max (min sb (pred sb)) (maxSignificand p - sa)
+    sz = max (pred (max 1 sb)) (maxSignificand p - sa)
 {-# INLINEABLE proposeExponentDiffOne #-}
 
 -- | [2^ex + sx, 2^ey + sy)

--- a/test/Doctest.hs
+++ b/test/Doctest.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = doctest ["src"]

--- a/test/NoDoctest.hs
+++ b/test/NoDoctest.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "\nNo doctest support"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -35,7 +35,7 @@ main =
   let p = 0.5
       n = 10
    in hspec $ describe "uniform" $ do
-        describe "rademacher tests" $ do
+        describe "rademacher-fpl tests" $ do
           specify "negative-interval" $ pendingWith "negative"
           specify "symmetric-interval" $ pendingWith "negative"
           describe "same exponent" $ do
@@ -63,7 +63,7 @@ main =
             describe "vbin-overflow" $ do
               specify "[a,b), abs(a) > abs(b)" $ pendingWith "negative"
               specify "[a,b), abs(a) >> abs(b)" $ pendingWith "negative"
-        describe "own tests" $ do
+        describe "own tests" $
           specify "full range" $
             isUniform (U 0 0) (U 15 7) 1 p
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import Control.Monad.ST (runST)
+import Data.Bits (shiftR)
+import Data.Proxy (Proxy (..))
+import Data.Word (Word64)
+import MonadIEEE (MonadIEEE (..), toUnsigned, toPositive, IEEERepr (..), Unsigned (..), Binary8)
+import Control.Monad (replicateM)
+import Statistics.Test.ChiSquared (chi2test)
+import Statistics.Test.Types (Test (..))
+import Statistics.Types (pValue)
+import Test.Hspec
+import Test.Validity (identity)
+import Uniform (uniformSigned)
+import Data.IORef (newIORef, readIORef, writeIORef)
+import Control.Monad.State.Strict (runState, evalState)
+import System.Random.SplitMix (mkSMGen)
+import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector.Unboxed.Mutable as MV
+import Data.Word (Word8)
+
+main :: IO ()
+main =
+  let x = U 0 1 :: Unsigned Binary8 Word8 Word8
+      y = U 3 4 :: Unsigned Binary8 Word8 Word8
+   in do
+     mapM_ (putStrLn . show . pUniform x y) [10,100]
+
+pUniform ::
+  Unsigned Binary8 Word8 Word8 ->
+  Unsigned Binary8 Word8 Word8 ->
+  Int ->
+    Double
+pUniform x y n =
+  let ept = V.map (*n) (expected x y) :: V.Vector Int
+      obs = observed' (V.sum ept) x y
+      inp = V.zip obs (V.map (fromIntegral :: Int -> Double) ept)
+      Just test = chi2test 1 inp
+   in pValue (testSignificance test)
+
+isUniform::
+  Unsigned Binary8 Word8 Word8 ->
+  Unsigned Binary8 Word8 Word8 ->
+  Int ->
+    Double -> Bool
+isUniform x y n p = pUniform x y n > p
+
+observed' ::
+  Int ->
+  Unsigned Binary8 Word8 Word8 ->
+  Unsigned Binary8 Word8 Word8 ->
+  V.Vector Int
+observed' n a b = V.create $ do
+      let u = uniformSigned (toPositive a) b
+      v <- MV.new (succ $ distance a b)
+      let loop 0 _ = return ()
+          loop m gen = do
+            let (x, gen') = runState u gen
+            MV.modify v succ (distance a (toUnsigned x))
+            loop (pred m) gen'
+      loop n (mkSMGen 1337)
+      return v
+
+-- main = hspec $ do
+--   describe "uniform" $ do
+--     it "has identity NaN" $ do
+--       identity uniform (read "NaN" :: Float)
+
+samples ::
+  forall f e s.
+  IEEERepr f e s =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  s ->
+  s
+samples a@(U ea sa) b@(U eb sb) width
+  | a >= b = error "a >= b"
+  | ea == eb =
+    let s = succ (sb - sa)
+     in width * s
+  | otherwise =
+    let s = succ (maxSignificand p - sa)
+        a' = U (succ ea) 0
+        width' = 2 * width
+     in width * s + samples a' b width'
+  where
+    p = Proxy :: Proxy f
+
+distance ::
+  forall f e s.
+  IEEERepr f e s =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  Int
+distance a@(U ea sa) b@(U eb sb)
+  -- | a > b = error "a > b"
+  | ea == eb = fromIntegral $ sb - sa
+  | otherwise = succ (fromIntegral (m - sa)) + distance (U (succ ea) 0) b
+  where
+    p = Proxy :: Proxy f
+    m = maxSignificand p
+{-# INLINE distance #-}
+
+observed ::
+  forall f e s.
+  IEEERepr f e s =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  [Unsigned f e s] ->
+  V.Vector Int
+observed a b xs = V.create $ do
+  v <- MV.new (succ $ distance a b)
+  mapM_ (\x -> MV.modify v succ (distance a x)) xs
+  return v
+
+next ::
+  forall f e s.
+  IEEERepr f e s =>
+  Unsigned f e s ->
+  Unsigned f e s
+next a@(U ea sa)
+  | sa == maxSignificand (Proxy :: Proxy f) = U (succ ea) 0
+  | otherwise = U ea (succ sa)
+
+fromTo ::
+  forall f e s.
+  IEEERepr f e s =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  [Unsigned f e s]
+fromTo a b
+  | a > b = error "a > b"
+  | a == b = [a]
+  | otherwise = a : fromTo (next a) b
+
+weight ::
+  forall f e s.
+  (IEEERepr f e s, Integral e) =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  Unsigned f e s ->
+  Word
+weight a@(U ea _) b u@(U eu su)
+  | a > u || u > b = error "a > u or u > b"
+  | a == u = 1
+  | b == u = w `div` 2
+  | su == 0 = 3 * (w `div` 4)
+  | otherwise = w
+  where
+    w = (2 :: Word) ^ (succ eu - ea)
+
+expected ::
+  forall f e s.
+    (IEEERepr f e s, Integral e) =>
+      Unsigned f e s ->
+        Unsigned f e s ->
+          V.Vector Int
+expected a b = V.fromList (map (fromIntegral . weight a b) (fromTo a b))
+
+  {-
+p ::
+  forall f e s.
+  (IEEERepr f e s, Integral e) =>
+  Unsigned f e s ->
+  Unsigned f e s ->
+  [Unsigned f e s] ->
+  Double
+p a b xs
+  | fromIntegral (V.sum obs) /= V.sum ept = error $ "sum(obs) = " ++ show (V.sum obs) ++ " sum(ept) = " ++ show (V.sum ept)
+  | otherwise = pValue (testSignificance test)
+  where
+    obs = observed a b xs
+    ept = V.map (*1000) $ expected a b
+    Just test = chi2test 0 (V.zip obs ept)
+    -}


### PR DESCRIPTION
```
uniform
  rademacher-fpl tests
    negative-interval
      # PENDING: negative
    symmetric-interval
      # PENDING: negative
    same exponent
      simple
      nextafter
    pow2
      one-two
      negative
        # PENDING: negative
      non-negative
        basic
          # PENDING: infinity
        vbin-overflow
          # PENDING: infinity
    a-pow2
      denormal-a
      normal-a
        basic
        vbin-overflow
    same-sign
      normal-a
        basic
        vbin-overflow
      denormal-a
    mixed-sign
      basic
        # PENDING: negative
      denormals
        # PENDING: negative
      vbin-overflow
        [a,b), abs(a) > abs(b)
          # PENDING: negative
        [a,b), abs(a) >> abs(b)
          # PENDING: negative
  own tests
    full range

Finished in 0.3227 seconds
19 examples, 0 failures, 9 pending
```